### PR TITLE
Investigate LiteLLM integration for RLLM endpoint switching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ openai
 anthropic
 python-dotenv
 pylatexenc
-sympy
+litellm

--- a/rllm_workflow/workflow.py
+++ b/rllm_workflow/workflow.py
@@ -16,18 +16,26 @@ from transformers import AutoTokenizer
 # Load environment variables from .env file
 load_dotenv()
 
+
 def main() -> None:
     """
-    Build the Strands agent and run rLLM workflow using OpenAI API.
+    Build the Strands agent and run rLLM workflow using OpenAI API (or LiteLLM proxy via base_url).
     """
-    print("--- Setting up rLLM Workflow for OpenAI ---")
+    print("--- Setting up rLLM Workflow (OpenAI-compatible) ---")
 
-    api_key = os.getenv("OPENAI_API_KEY")
+    # Read model/provider from env; works with OpenAI directly or LiteLLM proxy models
+    model_name = os.getenv("LLM_MODEL", "gpt-4o-mini")
+    base_url = os.getenv("LLM_BASE_URL")  # e.g., http://localhost:4000/v1 when using LiteLLM proxy
+
+    # API key: pass through to OpenAI or LiteLLM proxy
+    api_key = os.getenv("OPENAI_API_KEY") or os.getenv("LLM_API_KEY")
     if not api_key:
-        print("❌ OPENAI_API_KEY not found or not set in .env file.")
+        print("❌ OPENAI_API_KEY or LLM_API_KEY not found in environment.")
         return
 
-    print(f"✅ Found API key: {api_key[:10]}...")
+    print(f"✅ Using model: {model_name}")
+    if base_url:
+        print(f"✅ Using base_url: {base_url}")
 
     tokenizer = AutoTokenizer.from_pretrained("./local_tokenizer")
     print("✅ Loaded tokenizer")
@@ -37,20 +45,21 @@ def main() -> None:
         "env_class": StrandsEnv,
         "agent_args": {},
         "env_args": {},
+        # Keep engine OpenAI-compatible; route via LiteLLM if base_url is set
         "engine_name": "openai",
         "tokenizer": tokenizer,
         "sampling_params": {
-            "model": "gpt-4o-mini",  # Use o3-mini - the only model that works with completions API
-            "temperature": 0.7,  # Higher temperature for more creative responses
-            # Remove max_tokens from here to avoid duplicate parameter error
+            "model": model_name,
+            "temperature": float(os.getenv("LLM_TEMPERATURE", "0.7")),
         },
         "rollout_engine_args": {
             "api_key": api_key,
+            **({"base_url": base_url} if base_url else {}),
         },
-        "n_parallel_agents": 1,
-        "max_steps": 3,  # Allow up to 3 conversation turns
-        "max_response_length": 500,
-        "max_prompt_length": 2000,
+        "n_parallel_agents": int(os.getenv("N_PARALLEL_AGENTS", "1")),
+        "max_steps": int(os.getenv("MAX_STEPS", "3")),
+        "max_response_length": int(os.getenv("MAX_RESPONSE_LENGTH", "500")),
+        "max_prompt_length": int(os.getenv("MAX_PROMPT_LENGTH", "2000")),
     }
 
     print("Initializing AsyncAgentExecutionEngine...")
@@ -58,7 +67,7 @@ def main() -> None:
 
     tasks = [{"id": 0, "prompt": "Hello, who are you?"}]
 
-    print("Executing tasks with OpenAI...")
+    print("Executing tasks...")
     try:
         results = asyncio.run(engine.execute_tasks(tasks))
         print("\n--- Workflow Results ---")
@@ -66,7 +75,7 @@ def main() -> None:
             print(f"Task ID: {res.task.get('id')}")
             print(f"Final Reward: {res.reward}")
             print(f"Number of steps: {len(res.steps)}")
-            
+
             if res.steps:
                 for i, step in enumerate(res.steps):
                     print(f"Step {i}:")
@@ -84,6 +93,7 @@ def main() -> None:
         print(f"❌ An error occurred during task execution: {e}")
         import traceback
         traceback.print_exc()
+
 
 if __name__ == "__main__":
     main() 

--- a/rllm_workflow/workflow.py
+++ b/rllm_workflow/workflow.py
@@ -46,7 +46,7 @@ def main() -> None:
         "agent_args": {},
         "env_args": {},
         # Keep engine OpenAI-compatible; route via LiteLLM if base_url is set
-        "engine_name": "openai",
+        "engine_name": os.getenv("ENGINE_NAME", "openai"),
         "tokenizer": tokenizer,
         "sampling_params": {
             "model": model_name,


### PR DESCRIPTION
Configure LLM model and provider via environment variables to support diverse models and APIs.

The previous setup was tightly coupled to specific OpenAI models (e.g., `gpt-4o-mini`) due to rigid API assumptions (completions only). This change allows dynamic selection of models and providers (including Anthropic) by leveraging LiteLLM, either directly within the rLLM engine or via a LiteLLM proxy, abstracting away chat vs. completions API differences.

---
<a href="https://cursor.com/background-agent?bcId=bc-82f5d3a8-cad5-4584-998a-fecb4206d57d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-82f5d3a8-cad5-4584-998a-fecb4206d57d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

